### PR TITLE
Feature 0.4.0 range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "darkroom"
-version = "0.3.3-b"
+version = "0.3.4"
 description = "A contract testing tool built in Rust"
 authors = ["Matthew Planchard <msplanchard@gmail.com>", "Mikhail Katychev <mkatych@gmail.com>"]
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "darkroom"
-version = "0.3.4"
+version = "0.4.0"
 description = "A contract testing tool built in Rust"
 authors = ["Matthew Planchard <msplanchard@gmail.com>", "Mikhail Katychev <mkatych@gmail.com>"]
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "darkroom"
-version = "0.3.3-a"
+version = "0.3.3"
 description = "A contract testing tool built in Rust"
 authors = ["Matthew Planchard <msplanchard@gmail.com>", "Mikhail Katychev <mkatych@gmail.com>"]
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "darkroom"
-version = "0.3.3"
+version = "0.3.3-b"
 description = "A contract testing tool built in Rust"
 authors = ["Matthew Planchard <msplanchard@gmail.com>", "Mikhail Katychev <mkatych@gmail.com>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ dark --cut-out >(jq .IP) take ./test_data/post.01s.body.fr.json --cut ./test_dat
 
 * range is added to recordings: `dark record --range "<start_u32>:<end_u32>" ./dir/ my_reel_name`
 * `grpcurl` errors propagate to stdout properly
+* `"request"["form"]` request building URL functionality moved to `"request"["query"]`
+* `"request"["form"]` now properly bulids the form data of the HTTP request
 
 <!--
 VERSION="0.3.3-b"

--- a/README.md
+++ b/README.md
@@ -146,8 +146,12 @@ dark --cut-out >(jq .IP) take ./test_data/post.01s.body.fr.json --cut ./test_dat
 * `"request"["form"]` request building URL functionality moved to `"request"["query"]`
 * `"request"["form"]` now properly bulids the form data of the HTTP request
 
+#### `0.4.0`:
+
+* range is added to recordings: `dark record --range "<start_u32>:<end_u32>" ./dir/ my_reel_name`
+
 <!--
-VERSION="0.3.3-b"
+VERSION="0.4.0"
 DR_DIR=$PWD
 GRPCURL_DIR=${GRPCURL_DIR:-../grpcurl}
 cargo build --release && \

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ dark --cut-out >(jq .IP) take ./test_data/post.01s.body.fr.json --cut ./test_dat
 
 #### `0.3.3`:
 
-* range is added to recordings: `dark record --range "<start_num>:<end_num>" ./dir/ my_reel_name`
+* range is added to recordings: `dark record --range "<start_u32>:<end_u32>" ./dir/ my_reel_name`
 * `grpcurl` errors propagate to stdout properly
 
 <!--

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Options:
 
 <!-- dark record start -->
 ```
-Usage: dark record <reel_path> <reel_name> [<merge_cuts...>] [-c <cut>] [-b <component>] [-o <take-out>]
+Usage: dark record <reel_path> <reel_name> [<merge_cuts...>] [-c <cut>] [-b <component>] [-o <take-out>] [-r <range>]
 
 Attempts to play through an entire Reel sequence running a take for every frame in the sequence
 
@@ -71,6 +71,9 @@ Options:
   -b, --component   repeatable component reel pattern using an ampersand
                     separator: `--component "<dir>&<reel_name>"`
   -o, --take-out    output directory for successful takes
+  -r, --range       the range (inclusive) of frames that a record session will
+                    use, colon separated: `--range <start>:<end>` `--range
+                    <start>:`
   --help            display usage information
 
 ```
@@ -103,21 +106,21 @@ dark --cut-out >(jq .IP) take ./test_data/post.01s.body.fr.json --cut ./test_dat
 
 * HTTP support
 * added `form` key to HTTP frame requests: `{"request":{"uri":"POST post","form":{"key":"val","array[0]":"val0"}}}`
-* Full JSON object storage and retrieval, the cut register is no longer a flat associative array, strings are still used to map to JSON objects for templating
-* Variable discarding: `${lowercase}` variables will only be kept around for the duration of the frame
-* Headers and entrypoints can be stored and read on a per JSON frame basis
+* full JSON object storage and retrieval, the cut register is no longer a flat associative array, strings are still used to map to JSON objects for templating
+* variable discarding: `${lowercase}` variables will only be kept around for the duration of the frame
+* headers and entrypoints can be stored and read on a per JSON frame basis
 * SOPS/JSON secrets support
 
 #### `0.2.1`:
 
-* Added hidden variable support, hidden variables are defined with a leading underscore: `${_HIDDEN}`
-* Added `dark version` command
+* added hidden variable support, hidden variables are defined with a leading underscore: `${_HIDDEN}`
+* added `dark version` command
 * moved common parameters into the main `dark` command to be shared across subcommands
 
 #### `0.2.3`:
 
-* Added component reel support, component reels are generated as a prelude to the provided reel   `dark record --component "<dir>&<reel_name>" ./dir/ my_reel_name`
-* Added anyhow error handling
+* added component reel support, component reels are generated as a prelude to the provided reel   `dark record --component "<dir>&<reel_name>" ./dir/ my_reel_name`
+* added anyhow error handling
 * `--cut-out` can now be returned on a failed `record` or `take`
 
 #### `0.3.0`:
@@ -136,9 +139,13 @@ dark --cut-out >(jq .IP) take ./test_data/post.01s.body.fr.json --cut ./test_dat
 * `ToStringHidden` is now a generc trait
 * moved styler out of take.rs and into lib.rs
 
+#### `0.3.3`:
+
+* range is added to recordings: `dark record --record "<start_num>:<end_num>" ./dir/ my_reel_name`
+* `grpcurl` errors propagate to stdout properly
 
 <!--
-VERSION="0.3.2"
+VERSION="0.3.3"
 DR_DIR=$PWD
 GRPCURL_DIR=${GRPCURL_DIR:-../grpcurl}
 cargo build --release && \

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ dark --cut-out >(jq .IP) take ./test_data/post.01s.body.fr.json --cut ./test_dat
 * `grpcurl` errors propagate to stdout properly
 
 <!--
-VERSION="0.3.3"
+VERSION="0.3.3-b"
 DR_DIR=$PWD
 GRPCURL_DIR=${GRPCURL_DIR:-../grpcurl}
 cargo build --release && \

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ dark --cut-out >(jq .IP) take ./test_data/post.01s.body.fr.json --cut ./test_dat
 
 #### `0.3.3`:
 
-* range is added to recordings: `dark record --record "<start_num>:<end_num>" ./dir/ my_reel_name`
+* range is added to recordings: `dark record --range "<start_num>:<end_num>" ./dir/ my_reel_name`
 * `grpcurl` errors propagate to stdout properly
 
 <!--

--- a/filmreel/Cargo.toml
+++ b/filmreel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filmreel"
-version = "0.3.2"
+version = "0.3.3"
 description = "filmReel parser for Rust"
 authors = ["Mikhail Katychev <mkatych@gmail.com>"]
 edition = "2018"

--- a/filmreel/Cargo.toml
+++ b/filmreel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filmreel"
-version = "0.3.3"
+version = "0.3.2"
 description = "filmReel parser for Rust"
 authors = ["Mikhail Katychev <mkatych@gmail.com>"]
 edition = "2018"

--- a/filmreel/Cargo.toml
+++ b/filmreel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filmreel"
-version = "0.3.1"
+version = "0.3.2"
 description = "filmReel parser for Rust"
 authors = ["Mikhail Katychev <mkatych@gmail.com>"]
 edition = "2018"

--- a/filmreel/src/cut.rs
+++ b/filmreel/src/cut.rs
@@ -183,7 +183,7 @@ impl Register {
     // ensures string slice past is a singular declaration of a `"${VARIABLE}"`
     pub fn expect_standalone_var(var_name: &str, frame_str: &str) -> Result<(), FrError> {
         let expected = format!("{}{}{}", "${", var_name, "}");
-        if expected != frame_str.as_ref() {
+        if expected != frame_str {
             return Err(FrError::FrameParsef(
                 "Singe variable mismatch -",
                 format!("Expected:{}, Got:{}", expected, frame_str),
@@ -315,7 +315,10 @@ impl<'a> Match<'a> {
         // TODO refactor cthulu looking match arms
         match self {
             Match::Escape(range) => match json_value {
-                Value::String(json_str) => Ok(json_str.replace_range(range, "")),
+                Value::String(json_str) => {
+                    json_str.replace_range(range, "");
+                    Ok(())
+                }
                 _ => Err(FrError::ReadInstruction(
                     "Match::Escape.value is a non string Value",
                 )),
@@ -328,7 +331,10 @@ impl<'a> Match<'a> {
                 // if the match value is a string
                 Value::String(match_str) => match json_value {
                     // and the json value is as well, replace the range within
-                    Value::String(str_val) => Ok(str_val.replace_range(r, &match_str)),
+                    Value::String(str_val) => {
+                        str_val.replace_range(r, &match_str);
+                        Ok(())
+                    }
                     _ => Err(FrError::ReadInstruction(
                         "Match::Variable given a non string value to replace",
                     )),

--- a/filmreel/src/frame.rs
+++ b/filmreel/src/frame.rs
@@ -237,17 +237,10 @@ impl Request {
     }
 
     pub fn get_entrypoint(&self) -> Option<String> {
-        if self.entrypoint.is_none() {
-            return None;
+        if let Some(entrypoint) = self.entrypoint.clone() {
+            return Some(String::from(entrypoint.as_str()?));
         }
-        Some(
-            self.entrypoint
-                .clone()
-                .expect("get_entrypoint string option")
-                .as_str()
-                .expect("as_str cast failed for get_entrypoint")
-                .to_string(),
-        )
+        None
     }
 }
 

--- a/filmreel/src/reel.rs
+++ b/filmreel/src/reel.rs
@@ -47,12 +47,7 @@ impl Reel {
     pub fn success_only(self) -> Self {
         Self {
             dir: self.dir,
-            frames: self
-                .frames
-                .clone()
-                .into_iter()
-                .filter(|x| x.is_success())
-                .collect(),
+            frames: self.frames.into_iter().filter(|x| x.is_success()).collect(),
         }
     }
 

--- a/filmreel/src/utils.rs
+++ b/filmreel/src/utils.rs
@@ -73,6 +73,6 @@ pub fn get_jql_value(val: &Value, query: &str) -> Result<Value, FrError> {
             Value::String(_) => Ok(v),
             v => Ok(v),
         },
-        Err(e) => Err(FrError::ReadInstructionf("get_jql_value", String::from(e))),
+        Err(e) => Err(FrError::ReadInstructionf("get_jql_value", e)),
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -49,7 +49,6 @@ pub fn build_request(prm: Params, req: Request) -> Result<RequestBuilder, Error>
         Err(e) => return Err(Error::from(e)),
     }
 
-    // TODO dedupe these two parts
     match req.get_etc().get("form") {
         Some(Value::Object(f)) => builder = builder.form(&f),
         Some(Value::Null) | None => {}
@@ -67,23 +66,6 @@ pub fn build_request(prm: Params, req: Request) -> Result<RequestBuilder, Error>
     }
     Ok(builder)
 }
-
-// TODO pass in reqwest::RequestBuilder::{query,form} as methods
-//
-// fn build_from_etc<F>(
-//     val: Value,
-//     key: &str,
-//     builder: RequestBuilder,
-//     builder_method: F,
-// ) -> Result<RequestBuilder, Error>
-// where
-//     // T: Serialize + ?Sized,
-//     F: FnOnce(RequestBuilder, &BuilderParam) -> RequestBuilder,
-// {
-//     let val: BuilderParam = serde_json::from_value(val)
-//         .context(format!("request[\"{}\"] must be a key value map", key))?;
-//     Ok(builder_method(builder, &val))
-// }
 
 /// build_header constructs a header map from the header arg passed in from a ::Take or ::Record struct
 fn build_header(header: &str) -> Result<HeaderMap, Error> {

--- a/src/http.rs
+++ b/src/http.rs
@@ -13,7 +13,7 @@ use std::{
 use url::Url;
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
-struct Form {
+struct BuilderParam {
     #[serde(flatten)]
     form: BTreeMap<String, Value>,
 }
@@ -49,11 +49,17 @@ pub fn build_request(prm: Params, req: Request) -> Result<RequestBuilder, Error>
         Err(e) => return Err(Error::from(e)),
     }
 
-    let form = serde_json::from_value(req.get_etc()["form"].clone())?;
-    match form {
-        Value::Object(_) => builder = builder.query(&form),
-        Value::Null => {}
+    // TODO dedupe these two parts
+    match req.get_etc().get("form") {
+        Some(Value::Object(f)) => builder = builder.form(&f),
+        Some(Value::Null) | None => {}
         _ => return Err(anyhow!("request[\"form\"] must be a key value map")),
+    }
+
+    match req.get_etc().get("query") {
+        Some(Value::Object(f)) => builder = builder.query(&f),
+        Some(Value::Null) | None => {}
+        _ => return Err(anyhow!("request[\"query\"] must be a key value map")),
     }
 
     if let Some(h) = prm.header {
@@ -61,6 +67,23 @@ pub fn build_request(prm: Params, req: Request) -> Result<RequestBuilder, Error>
     }
     Ok(builder)
 }
+
+// TODO pass in reqwest::RequestBuilder::{query,form} as methods
+//
+// fn build_from_etc<F>(
+//     val: Value,
+//     key: &str,
+//     builder: RequestBuilder,
+//     builder_method: F,
+// ) -> Result<RequestBuilder, Error>
+// where
+//     // T: Serialize + ?Sized,
+//     F: FnOnce(RequestBuilder, &BuilderParam) -> RequestBuilder,
+// {
+//     let val: BuilderParam = serde_json::from_value(val)
+//         .context(format!("request[\"{}\"] must be a key value map", key))?;
+//     Ok(builder_method(builder, &val))
+// }
 
 /// build_header constructs a header map from the header arg passed in from a ::Take or ::Record struct
 fn build_header(header: &str) -> Result<HeaderMap, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,11 @@ pub struct Record {
     /// output directory for successful takes
     #[argh(option, short = 'o')]
     take_out: Option<PathBuf>,
+
+    /// specifies the range inclusive list of frames to provied to the Reel object, colon
+    /// separated: `--range 2:`
+    #[argh(option, short = 'r')]
+    range: Option<String>,
 }
 
 impl Take {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,8 +169,7 @@ pub struct Record {
     #[argh(option, short = 'o')]
     take_out: Option<PathBuf>,
 
-    /// specifies the range inclusive list of frames to provied to the Reel object, colon
-    /// separated: `--range 2:`
+    /// the range (inclusive) of frames that a record session will use, colon separated: `--range <start>:<end>` `--range <start>:`
     #[argh(option, short = 'r')]
     range: Option<String>,
 }

--- a/src/record.rs
+++ b/src/record.rs
@@ -34,7 +34,7 @@ pub fn run_record(cmd: Record, base_params: BaseParams) -> Result<(), Error> {
         .flat_map(fr::file_to_string)
         .map(Register::from)
         .collect();
-    &cut_register.destructive_merge(merge_cuts?);
+    cut_register.destructive_merge(merge_cuts?);
 
     for meta_frame in comp_reels.into_iter().flatten() {
         // if cmd.output is Some, provide a take PathBuf
@@ -115,7 +115,7 @@ pub fn init_components(components: Vec<String>) -> Result<(Vec<Reel>, Register),
     for comp in components {
         let (reel, register) = parse_component(comp)?;
         // TODO implement single merge
-        &comp_reg.destructive_merge(vec![register]);
+        comp_reg.destructive_merge(vec![register]);
         reels.push(reel);
     }
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -163,7 +163,7 @@ where
 {
     match str_range
         .as_ref()
-        .splitn(3, ':')
+        .splitn(2, ':')
         .collect::<Vec<&str>>()
         .as_slice()
     {

--- a/src/record.rs
+++ b/src/record.rs
@@ -155,7 +155,7 @@ fn parse_component(component: String) -> Result<(Reel, Register), Error> {
 }
 
 type ParsedRange = Option<Range<u32>>;
-// parse_range parses the `"<start_num>:<end_num>"` provided to the `--range` cli argument
+// parse_range parses the `"<start_u32>:<end_u32>"` provided to the `--range` cli argument
 // returning a range object
 fn parse_range<T>(str_range: T) -> Result<ParsedRange, Error>
 where

--- a/src/record.rs
+++ b/src/record.rs
@@ -50,7 +50,6 @@ pub fn run_record(cmd: Record, base_params: BaseParams) -> Result<(), Error> {
                 .context("unable to unwrap MetaFrame.path")?
         );
         warn!("{}", "=======================".green());
-        continue;
 
         let frame_str = fr::file_to_string(&meta_frame.path)?;
         let frame = Frame::new(&frame_str)?;


### PR DESCRIPTION
* range is added to recordings: `dark record --range "<start_num>:<end_num>" ./dir/ my_reel_name`, allowing one to limit  what frames run in a record session
* `grpcurl` errors propagate to stdout properly
