### PR TITLE
Feature 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,20 +23,20 @@ members = [
 [dependencies]
 anyhow = "1.0"
 argh = "0.1"
-colored = "1.9"
+colored = "2.0"
 colored-diff = "0.2"
 colored_json = "2"
-filmreel = { version = "0.3", path = "filmreel" }
+filmreel = { version = "0.4", path = "filmreel" }
 http = "0.2"
 lazy_static = "1.4"
 log = { version = "0.4", features = ["std"] }
 prettytable-rs = "^0.8"
 reqwest = { version = "0.10", features = ["blocking", "json"] }
-serde = { version = "1.0.104", features = ["derive"] }
-serde_json = "1.0.44"
-url = "2.1"
-which = "3.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+url = "2.2"
+which = "4.0"
 chrono = "0.4"
 
 [dev-dependencies]
-rstest = "0.5"
+rstest = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "darkroom"
-version = "0.5.0-a"
+version = "0.5.0"
 description = "A contract testing tool built in Rust"
 authors = ["Matthew Planchard <msplanchard@gmail.com>", "Mikhail Katychev <mkatych@gmail.com>"]
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.44"
 url = "2.1"
 which = "3.1"
+chrono = "0.4"
 
 [dev-dependencies]
 rstest = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "darkroom"
-version = "0.4.0"
+version = "0.5.0-a"
 description = "A contract testing tool built in Rust"
 authors = ["Matthew Planchard <msplanchard@gmail.com>", "Mikhail Katychev <mkatych@gmail.com>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A contract testing tool built in Rust using the [filmReel format](https://github
 ```
 Usage: dark [<address>] [-v] [--tls] [-p <proto>] [-H <header>] [-C <cut-out>] [-i] <command> [<args>]
 
-Top-level command.
+Darkroom: A contract testing tool built in Rust using the filmReel format.
 
 Options:
   -v, --verbose     enable verbose output
@@ -73,9 +73,9 @@ Options:
   -o, --take-out    output directory for successful takes
   -r, --range       the range (inclusive) of frames that a record session will
                     use, colon separated: --range <start>:<end> --range <start>:
-  -t, --timeout     HTTP/S client request timeout in seconds, --timeout 0
-                    disables request timeout [default: 30]
-  -s, --timestamp   return timestamp at execution start, error return, and reel
+  -t, --timeout     client request timeout in seconds, --timeout 0 disables
+                    request timeout [default: 30]
+  -s, --timestamp   print timestamp at take start, error return, and reel
                     completion
   --help            display usage information
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ dark --cut-out >(jq .IP) take ./test_data/post.01s.body.fr.json --cut ./test_dat
 
 * timestamps are added to recordings: `dark record record ./test_data post --timestamp`
 * 30 sec default timeout can now be overridden: `dark record record ./test_data post --timeout 2`
+* reel sequence numbers are now checked for duplicates
 
 <!--
 VERSION="0.5.0"

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ dark --cut-out >(jq .IP) take ./test_data/post.01s.body.fr.json --cut ./test_dat
 * 30 sec default timeout can now be overridden: `dark record record ./test_data post --timeout 2`
 
 <!--
-VERSION="0.5.0-a"
+VERSION="0.5.0"
 DR_DIR=$PWD
 GRPCURL_DIR=${GRPCURL_DIR:-../grpcurl}
 cargo build --release && \

--- a/README.md
+++ b/README.md
@@ -150,8 +150,13 @@ dark --cut-out >(jq .IP) take ./test_data/post.01s.body.fr.json --cut ./test_dat
 
 * range is added to recordings: `dark record --range "<start_u32>:<end_u32>" ./dir/ my_reel_name`
 
+#### `0.5.0`:
+
+* timestamps are added to recordings: `dark record record ./test_data post --timestamp`
+* 30 sec default timeout can now be overridden: `dark record record ./test_data post --timeout 2`
+
 <!--
-VERSION="0.4.0"
+VERSION="0.5.0a"
 DR_DIR=$PWD
 GRPCURL_DIR=${GRPCURL_DIR:-../grpcurl}
 cargo build --release && \

--- a/README.md
+++ b/README.md
@@ -62,18 +62,21 @@ Options:
 
 <!-- dark record start -->
 ```
-Usage: dark record <reel_path> <reel_name> [<merge_cuts...>] [-c <cut>] [-b <component>] [-o <take-out>] [-r <range>]
+Usage: dark record <reel_path> <reel_name> [<merge_cuts...>] [-c <cut>] [-b <component>] [-o <take-out>] [-r <range>] [-t <timeout>] [-s]
 
 Attempts to play through an entire Reel sequence running a take for every frame in the sequence
 
 Options:
   -c, --cut         filepath of input cut file
   -b, --component   repeatable component reel pattern using an ampersand
-                    separator: `--component "<dir>&<reel_name>"`
+                    separator: --component "<dir>&<reel_name>"
   -o, --take-out    output directory for successful takes
   -r, --range       the range (inclusive) of frames that a record session will
-                    use, colon separated: `--range <start>:<end>` `--range
-                    <start>:`
+                    use, colon separated: --range <start>:<end> --range <start>:
+  -t, --timeout     HTTP/S client request timeout in seconds, --timeout 0
+                    disables request timeout [default: 30]
+  -s, --timestamp   return timestamp at execution start, error return, and reel
+                    completion
   --help            display usage information
 
 ```
@@ -156,7 +159,7 @@ dark --cut-out >(jq .IP) take ./test_data/post.01s.body.fr.json --cut ./test_dat
 * 30 sec default timeout can now be overridden: `dark record record ./test_data post --timeout 2`
 
 <!--
-VERSION="0.5.0a"
+VERSION="0.5.0-a"
 DR_DIR=$PWD
 GRPCURL_DIR=${GRPCURL_DIR:-../grpcurl}
 cargo build --release && \

--- a/filmreel/Cargo.toml
+++ b/filmreel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filmreel"
-version = "0.3.2"
+version = "0.4.0"
 description = "filmReel parser for Rust"
 authors = ["Mikhail Katychev <mkatych@gmail.com>"]
 edition = "2018"
@@ -16,13 +16,13 @@ name = "filmreel"
 path = "src/lib.rs"
 
 [dependencies]
-colored = "1.9"
+colored = "2.0"
 glob  = "0.3"
-jql = "2.5"
+jql = "2.8"
 lazy_static = "1.4.0"
-regex = "1.3.3"
-serde = { version = "1.0.104", features = ["derive"] }
-serde_json = "1.0.44"
+regex = "1.4"
+serde = { version = "1.0.118", features = ["derive"] }
+serde_json = "1.0"
 
 [dev-dependencies]
-rstest = "0.5"
+rstest = "0.6"

--- a/filmreel/src/reel.rs
+++ b/filmreel/src/reel.rs
@@ -1,6 +1,7 @@
 use crate::error::FrError;
 use glob::glob;
 use std::{
+    collections::HashMap,
     convert::TryFrom,
     ffi::OsStr,
     iter::FromIterator,
@@ -18,6 +19,10 @@ pub struct Reel {
     frames: Vec<MetaFrame>,
 }
 
+const SEQUENCE_DUPE_ERR: &str = "Associated frames cannot share the same sequence number";
+const METAFRAME_DELIMIT_ERR: &str =
+    "Frame filename mast have exactly 3 period delimited sections preceding '.fr.json'";
+
 impl Reel {
     /// A new reel is created from a provided Path or PathBuf
     pub fn new<P>(dir: P, reel_name: &str, range: Option<Range<u32>>) -> Result<Self, FrError>
@@ -31,10 +36,12 @@ impl Reel {
         // sort by string value since sorting by f32 is not idiomatic
         frames.sort_by(|a, b| a.path.cmp(&b.path));
 
-        Ok(Self {
+        let reel = Self {
             dir: PathBuf::from(dir.as_ref().to_str().expect("None Reel dir")),
             frames,
-        })
+        };
+        reel.validate()?;
+        Ok(reel)
     }
 
     /// convenience function to get default associated cut file
@@ -49,6 +56,21 @@ impl Reel {
             dir: self.dir,
             frames: self.frames.into_iter().filter(|x| x.is_success()).collect(),
         }
+    }
+
+    /// Ensure that the Reel is valid
+    pub fn validate(&self) -> Result<(), FrError> {
+        let mut sequence_set = HashMap::new();
+        // ensure that the Reel has no duplicate sequence number
+        for frame in self.frames.iter() {
+            if let Some(dupe_ref) = sequence_set.insert(&frame.step, frame.get_filename()) {
+                return Err(FrError::ReelParsef(
+                    SEQUENCE_DUPE_ERR,
+                    format!("{} and {}", dupe_ref, frame.get_filename()),
+                ));
+            }
+        }
+        Ok(())
     }
 
     // get_frame_dir_glob returns a glob pattern corresponding to all the Frame JSON files contained in
@@ -74,6 +96,8 @@ impl Reel {
     where
         T: AsRef<OsStr>,
     {
+        // Associate the range with permitted whole sequence values
+        // if an Option::None range was passed, all frames are permitted
         let permit_frame: Box<dyn Fn(u32) -> bool> = match range {
             Some(r) => Box::new(move |n| r.contains(&n)),
             None => Box::new(|_| true),
@@ -87,7 +111,7 @@ impl Reel {
             .filter(|path| path.is_file())
         {
             let frame = MetaFrame::try_from(entry)?;
-            if permit_frame(frame.step as u32) {
+            if permit_frame(frame.step_f3.trunc() as u32) {
                 frames.push(frame);
             }
         }
@@ -121,11 +145,12 @@ impl IntoIterator for Reel {
 ///
 #[derive(Clone, PartialEq, Debug)]
 pub struct MetaFrame {
-    pub path: PathBuf,
-    pub name: String,
     pub reel_name: String,
-    pub step: f32,
     pub frame_type: FrameType,
+    pub name: String,
+    pub path: PathBuf,
+    pub step_f3: f32,
+    step: String,
 }
 
 impl TryFrom<PathBuf> for MetaFrame {
@@ -143,20 +168,21 @@ impl TryFrom<PathBuf> for MetaFrame {
         };
 
         let reel_name = String::from(reel_parts.remove(0));
-        let (seq, fr_type) = parse_sequence(reel_parts.remove(0))?;
+        let sequence_number = reel_parts.remove(0);
+        let (seq, fr_type) = parse_sequence(sequence_number)?;
         let name = reel_parts.remove(0);
 
         // only three indices should be present when split on '.'
-        assert!(
-            reel_parts.is_empty(),
-            "frame name should only have 3 period delimited sections ending with '.fr.json'"
-        );
+        if !reel_parts.is_empty() {
+            return Err(FrError::ReelParse(METAFRAME_DELIMIT_ERR));
+        }
 
         Ok(Self {
             path: p.clone(),
             name: name.to_string(),
             reel_name,
-            step: seq,
+            step_f3: seq,
+            step: sequence_number.to_string(),
             frame_type: fr_type,
         })
     }
@@ -168,10 +194,8 @@ impl MetaFrame {
     }
 
     // get_filename returns the str representation of the MetaFrame.path file stem
-    pub fn get_filename(&self) -> Option<String> {
-        self.path
-            .file_stem()
-            .map(|x| String::from(x.to_string_lossy()))
+    pub fn get_filename(&self) -> String {
+        return format!("{}.{}.{}.fr.json", self.reel_name, self.step, self.name);
     }
 }
 
@@ -248,7 +272,8 @@ mod tests {
     #[rstest(input, expected,
         case("02se", (2.0, FrameType::PsError)),
         case("10s_1", (10.1, FrameType::Success)),
-        case("011e_8", (11.8, FrameType::Error))
+        case("011e_8", (11.8, FrameType::Error)),
+        case("01e", (1.0, FrameType::Error)),
         )]
     fn test_parse_sequence(input: &str, expected: (f32, FrameType)) {
         match parse_sequence(input) {
@@ -267,9 +292,39 @@ mod tests {
                 name: "frame_name".to_string(),
                 path: PathBuf::from("./reel_name.01s.frame_name.fr.json"),
                 reel_name: "reel_name".to_string(),
-                step: 1.0,
+                step: "01s".to_string(),
+                step_f3: 1.0,
             },
             try_path
+        );
+    }
+
+    #[test]
+    fn test_validate() {
+        let reel = Reel {
+            dir: ".".into(),
+            frames: vec![
+                MetaFrame::try_from(PathBuf::from("./reel.01s.frame1.fr.json")).unwrap(),
+                MetaFrame::try_from(PathBuf::from("./reel.01e.frame2.fr.json")).unwrap(),
+            ],
+        };
+        assert!(reel.validate().is_ok());
+    }
+    #[test]
+    fn test_validate_err() {
+        let reel = Reel {
+            dir: ".".into(),
+            frames: vec![
+                MetaFrame::try_from(PathBuf::from("./reel.01s.frame1.fr.json")).unwrap(),
+                MetaFrame::try_from(PathBuf::from("./reel.01s.frame2.fr.json")).unwrap(),
+            ],
+        };
+        assert_eq!(
+            reel.validate().unwrap_err(),
+            FrError::ReelParsef(
+                SEQUENCE_DUPE_ERR,
+                "reel.01s.frame1.fr.json and reel.01s.frame2.fr.json".to_string()
+            )
         );
     }
 }

--- a/filmreel/src/reel.rs
+++ b/filmreel/src/reel.rs
@@ -111,7 +111,7 @@ impl Reel {
             .filter(|path| path.is_file())
         {
             let frame = MetaFrame::try_from(entry)?;
-            if permit_frame(frame.step_f3.trunc() as u32) {
+            if permit_frame(frame.step_f32.trunc() as u32) {
                 frames.push(frame);
             }
         }
@@ -149,7 +149,7 @@ pub struct MetaFrame {
     pub frame_type: FrameType,
     pub name: String,
     pub path: PathBuf,
-    pub step_f3: f32,
+    pub step_f32: f32,
     step: String,
 }
 
@@ -181,7 +181,7 @@ impl TryFrom<PathBuf> for MetaFrame {
             path: p.clone(),
             name: name.to_string(),
             reel_name,
-            step_f3: seq,
+            step_f32: seq,
             step: sequence_number.to_string(),
             frame_type: fr_type,
         })
@@ -293,7 +293,7 @@ mod tests {
                 path: PathBuf::from("./reel_name.01s.frame_name.fr.json"),
                 reel_name: "reel_name".to_string(),
                 step: "01s".to_string(),
-                step_f3: 1.0,
+                step_f32: 1.0,
             },
             try_path
         );

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -64,13 +64,12 @@ pub fn request(prm: Params, req: Request) -> Result<Response, Error> {
         },
         Some(_) => {
             let err: ResponseError = serde_json::from_slice(&req_cmd.stderr).map_err(|_| {
-                // if we fail to map to a serde struct, stringingfy stderr bytes and cast
-                // to anyhow error
+                // if we fail to map to a serde struct, stringingfy stderr bytes and cast to anyhow error
                 String::from_utf8(req_cmd.stderr)
                     .map_err(Error::from)
                     .map(|v| anyhow!(v))
                     .context("grpcurl error")
-                    .unwrap_err()
+                    .unwrap_or_else(|e| e)
             })?;
             // create frame response from deserialized grpcurl error
             Response {

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -47,6 +47,8 @@ pub fn request(prm: Params, req: Request) -> Result<Response, Error> {
 
     let req_cmd = Command::new("grpcurl")
         .args(flags)
+        .arg("-connect-timeout")
+        .arg(format!("{:.1}", prm.timeout as f32))
         .arg("-d")
         .arg(req.to_payload()?)
         .arg(prm.address)
@@ -54,19 +56,22 @@ pub fn request(prm: Params, req: Request) -> Result<Response, Error> {
         .output()
         .context("failed to execute grpcurl process")?;
 
-    if req_cmd.stderr.len() > 0 {
-        let grpcurl_err_msg = String::from_utf8(req_cmd.stderr.clone())?;
-        return Err(anyhow!(grpcurl_err_msg).context("grpcurl error"));
-    }
-
-    let response: Response = match req_cmd.status.code() {
+    let response = match req_cmd.status.code() {
         Some(0) => Response {
             body: serde_json::from_slice(&req_cmd.stdout)?,
             status: 0,
             etc: json!({}),
         },
         Some(_) => {
-            let err: ResponseError = serde_json::from_slice(&req_cmd.stderr)?;
+            let err: ResponseError = serde_json::from_slice(&req_cmd.stderr).map_err(|_| {
+                // if we fail to map to a serde struct, stringingfy stderr bytes and cast
+                // to anyhow error
+                String::from_utf8(req_cmd.stderr)
+                    .map_err(Error::from)
+                    .map(|v| anyhow!(v))
+                    .context("grpcurl error")
+                    .unwrap_err()
+            })?;
             // create frame response from deserialized grpcurl error
             Response {
                 body: Some(serde_json::Value::String(err.message)),
@@ -74,7 +79,7 @@ pub fn request(prm: Params, req: Request) -> Result<Response, Error> {
                 etc: json!({}),
             }
         }
-        None => return Err(anyhow!("grpcurl Response code was <None>")),
+        None => return Err(anyhow!("grpcurl response code was <None>")),
     };
     Ok(response)
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -37,7 +37,16 @@ pub fn build_request(prm: Params, req: Request) -> Result<RequestBuilder, Error>
     {
         [method_str, tail_str] => {
             method = Method::from_bytes(method_str.as_bytes())?;
-            endpoint = Url::parse(prm.address.as_str())?.join(tail_str)?;
+            let entrypoint = prm.address.clone();
+            endpoint = Url::parse(&entrypoint)
+                .context(format!("base url: {}", entrypoint))?
+                .join(tail_str)
+                .context(format!(
+                    "base url: {},
+This is the case if the scheme and : delimiter are not followed by a / slash,
+as is typically the case of 'data:' mailto: URLs, and localhost without a leading http:// or https://",
+                    entrypoint
+                ))?;
         }
         _ => {
             return Err(anyhow!("unable to parse request uri field"));

--- a/src/http.rs
+++ b/src/http.rs
@@ -37,14 +37,13 @@ pub fn build_request(prm: Params, req: Request) -> Result<RequestBuilder, Error>
     {
         [method_str, tail_str] => {
             method = Method::from_bytes(method_str.as_bytes())?;
-            let entrypoint = prm.address.clone();
+            let entrypoint = prm.address;
             endpoint = Url::parse(&entrypoint)
                 .context(format!("base url: {}", entrypoint))?
                 .join(tail_str)
                 .context(format!(
-                    "base url: {},
-This is the case if the scheme and : delimiter are not followed by a / slash,
-as is typically the case of 'data:' mailto: URLs, and localhost without a leading http:// or https://",
+                    "base url: {}, This is the case if the scheme and ':' delimiter are not followed by a '/',
+such as 'data:' mailto: URLs, and localhost without a leading http:// or https://",
                     entrypoint
                 ))?;
         }

--- a/src/http.rs
+++ b/src/http.rs
@@ -9,6 +9,7 @@ use serde_json::{json, Value};
 use std::{
     collections::{BTreeMap, HashMap},
     convert::TryFrom,
+    time::Duration,
 };
 use url::Url;
 
@@ -22,6 +23,11 @@ struct BuilderParam {
 pub fn build_request(prm: Params, req: Request) -> Result<RequestBuilder, Error> {
     let method: Method;
     let endpoint: Url;
+
+    let timeout = match prm.timeout {
+        0 => None,
+        _ => Some(Duration::from_secs(prm.timeout)),
+    };
 
     match &req
         .get_uri()
@@ -38,7 +44,10 @@ pub fn build_request(prm: Params, req: Request) -> Result<RequestBuilder, Error>
         }
     };
 
-    let mut builder = Client::builder().build()?.request(method, endpoint);
+    let mut builder = Client::builder()
+        .timeout(timeout)
+        .build()?
+        .request(method, endpoint);
     match req.to_val_payload() {
         Ok(b) => {
             // TODO handle empty body better

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ impl log::Log for Logger {
     fn flush(&self) {}
 }
 
-/// Top-level command.
+/// Darkroom: A contract testing tool built in Rust using the filmReel format.
 #[derive(FromArgs, PartialEq, Debug)]
 pub struct Command {
     /// enable verbose output
@@ -175,13 +175,16 @@ pub struct Record {
     #[argh(option, short = 'r')]
     range: Option<String>,
 
-    /// HTTP/S client request timeout in seconds, --timeout 0 disables request timeout [default: 30]
+    /// client request timeout in seconds, --timeout 0 disables request timeout [default: 30]
     #[argh(option, short = 't', default = "30")]
     timeout: u64,
 
     /// return timestamp at execution start, error return, and reel completion
     #[argh(switch, short = 's')]
     timestamp: bool,
+    // forces shape mismatches to be diffed rather than return expected/actual statements
+    // #[argh(switch)]
+    // force_diff: bool,
 }
 
 impl Take {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@ pub struct Record {
     #[argh(option, short = 't', default = "30")]
     timeout: u64,
 
-    /// return timestamp at execution start, error return, and reel completion
+    /// print timestamp at take start, error return, and reel completion
     #[argh(switch, short = 's')]
     timestamp: bool,
     // forces shape mismatches to be diffed rather than return expected/actual statements

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,8 @@ pub struct Command {
 impl Command {
     pub fn base_params(&self) -> BaseParams {
         BaseParams {
+            timeout: 30,
+            timestamp: false,
             tls: self.tls,
             header: self.header.clone(),
             address: self.address.clone(),
@@ -157,7 +159,7 @@ pub struct Record {
     #[argh(option, short = 'c')]
     cut: Option<PathBuf>,
 
-    /// repeatable component reel pattern using an ampersand separator: `--component "<dir>&<reel_name>"`
+    /// repeatable component reel pattern using an ampersand separator: --component "<dir>&<reel_name>"
     #[argh(option, short = 'b')]
     component: Vec<String>,
 
@@ -169,9 +171,17 @@ pub struct Record {
     #[argh(option, short = 'o')]
     take_out: Option<PathBuf>,
 
-    /// the range (inclusive) of frames that a record session will use, colon separated: `--range <start>:<end>` `--range <start>:`
+    /// the range (inclusive) of frames that a record session will use, colon separated: --range <start>:<end> --range <start>:
     #[argh(option, short = 'r')]
     range: Option<String>,
+
+    /// HTTP/S client request timeout in seconds, --timeout 0 disables request timeout [default: 30]
+    #[argh(option, short = 't', default = "30")]
+    timeout: u64,
+
+    /// return timestamp at execution start, error return, and reel completion
+    #[argh(switch, short = 's')]
+    timestamp: bool,
 }
 
 impl Take {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ impl Command {
     pub fn base_params(&self) -> BaseParams {
         BaseParams {
             timeout: 30,
-            timestamp: false,
+            use_timestamp: false,
             tls: self.tls,
             header: self.header.clone(),
             address: self.address.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,10 +28,12 @@ fn main() -> Result<(), Error> {
         }
         SubCommand::Record(cmd) => {
             cmd.validate()?;
-            match run_record(cmd, base_params) {
+            match run_record(cmd, base_params.clone()) {
                 Err(e) => {
-                    write!(io::stderr(), "[{}] ", chrono::Utc::now())
-                        .expect("write to stderr panic");
+                    if base_params.use_timestamp {
+                        write!(io::stderr(), "[{}] ", chrono::Utc::now())
+                            .expect("write to stderr panic");
+                    }
                     Err(e)
                 }
                 _ => Ok(()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
-use anyhow::{anyhow, Error};
+use anyhow::Error;
 use darkroom::{record::run_record, take::single_take, *};
+use std::io::{self, Write};
 
 fn main() -> Result<(), Error> {
     let args: Command = argh::from_env();
@@ -28,7 +29,11 @@ fn main() -> Result<(), Error> {
         SubCommand::Record(cmd) => {
             cmd.validate()?;
             match run_record(cmd, base_params) {
-                Err(e) => Err(anyhow!("{}{}", params::fmt_timestamp(true), e)),
+                Err(e) => {
+                    write!(io::stderr(), "[{}] ", chrono::Utc::now())
+                        .expect("write to stderr panic");
+                    Err(e)
+                }
                 _ => Ok(()),
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::Error;
+use anyhow::{anyhow, Error};
 use darkroom::{record::run_record, take::single_take, *};
 
 fn main() -> Result<(), Error> {
@@ -27,8 +27,10 @@ fn main() -> Result<(), Error> {
         }
         SubCommand::Record(cmd) => {
             cmd.validate()?;
-            run_record(cmd, base_params)?;
-            Ok(())
+            match run_record(cmd, base_params) {
+                Err(e) => Err(anyhow!("{}{}", params::fmt_timestamp(true), e)),
+                _ => Ok(()),
+            }
         }
     }
 }

--- a/src/params.rs
+++ b/src/params.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct Params<'a> {
     pub timeout: u64,
-    pub timestamp: bool,
+    pub use_timestamp: bool,
     pub tls: bool,
     pub header: Option<String>,
     pub address: String,
@@ -18,21 +18,16 @@ pub struct Params<'a> {
 }
 
 impl<'a> Params<'a> {
-    pub fn get_timestamp(&self) -> String {
-        fmt_timestamp(self.timestamp)
+    pub fn fmt_timestamp(&self) -> String {
+        if self.use_timestamp {
+            return format!("[{}] ", chrono::Utc::now());
+        }
+        "".to_string()
     }
 
     pub fn error_timestamp(&self) {
-        error_timestamp(self.timestamp)
+        error_timestamp(self.use_timestamp)
     }
-}
-
-// TODO rename
-pub fn fmt_timestamp(timestamp: bool) -> String {
-    if timestamp {
-        return format!("[{}] ", chrono::Utc::now());
-    }
-    return "".to_string();
 }
 
 // TODO rename
@@ -54,7 +49,7 @@ pub fn warn_timestamp(timestamp: bool) {
 #[derive(Clone)]
 pub struct BaseParams {
     pub timeout: u64,
-    pub timestamp: bool,
+    pub use_timestamp: bool,
     pub tls: bool,
     pub header: Option<String>,
     pub address: Option<String>,
@@ -74,7 +69,7 @@ impl From<&Command> for BaseParams {
     fn from(cmd: &Command) -> Self {
         Self {
             timeout: 30,
-            timestamp: false,
+            use_timestamp: false,
             tls: cmd.tls,
             header: cmd.header.clone(),
             address: cmd.address.clone(),
@@ -116,7 +111,7 @@ impl BaseParams {
 
         Ok(Params {
             timeout: self.timeout,
-            timestamp: self.timestamp,
+            use_timestamp: self.use_timestamp,
             tls: self.tls,
             header,
             address,
@@ -127,7 +122,7 @@ impl BaseParams {
     pub fn with_timeout(self, timeout: u64) -> Self {
         BaseParams {
             timeout,
-            timestamp: self.timestamp,
+            use_timestamp: self.use_timestamp,
             tls: self.tls,
             header: self.header.clone(),
             address: self.address.clone(),
@@ -140,7 +135,7 @@ impl BaseParams {
     pub fn with_timestamp(self, timestamp: bool) -> Self {
         BaseParams {
             timeout: self.timeout,
-            timestamp,
+            use_timestamp: timestamp,
             tls: self.tls,
             header: self.header.clone(),
             address: self.address.clone(),
@@ -150,11 +145,14 @@ impl BaseParams {
             verbose: self.verbose,
         }
     }
-    pub fn get_timestamp(&self) -> String {
-        fmt_timestamp(self.timestamp)
+    pub fn fmt_timestamp(&self) -> String {
+        if self.use_timestamp {
+            return format!("[{}] ", chrono::Utc::now());
+        }
+        "".to_string()
     }
     pub fn warn_timestamp(&self) {
-        warn_timestamp(self.timestamp)
+        warn_timestamp(self.use_timestamp)
     }
 }
 
@@ -217,7 +215,7 @@ mod tests {
         assert_eq!(
             Params {
                 timeout: 30,
-                timestamp: false,
+                use_timestamp: false,
                 tls: false,
                 header: Some("\"Authorization: Bearer BIG_BEAR\"".to_string()),
                 address: "localhost:8000".to_string(),

--- a/src/record.rs
+++ b/src/record.rs
@@ -49,9 +49,7 @@ pub fn run_record(cmd: Record, mut base_params: BaseParams) -> Result<(), Error>
             "{}{} {:?}",
             base_params.fmt_timestamp(),
             "File:".yellow(),
-            meta_frame
-                .get_filename()
-                .context("unable to unwrap MetaFrame.path")?
+            meta_frame.get_filename()
         );
         warn!("{}", "=======================".green());
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -47,7 +47,7 @@ pub fn run_record(cmd: Record, mut base_params: BaseParams) -> Result<(), Error>
             .map(|dir| take_output(&dir, &&meta_frame.path));
         warn!(
             "{}{} {:?}",
-            base_params.get_timestamp(),
+            base_params.fmt_timestamp(),
             "File:".yellow(),
             meta_frame
                 .get_filename()
@@ -65,9 +65,9 @@ pub fn run_record(cmd: Record, mut base_params: BaseParams) -> Result<(), Error>
             return Err(e);
         }
     }
-    base_params.warn_timestamp();
     warn!(
-        "{}{}{}",
+        "{}{}{}{}",
+        base_params.fmt_timestamp(),
         "= ".green(),
         "Success 🎉 ".yellow(),
         "==========\n".green()

--- a/src/record.rs
+++ b/src/record.rs
@@ -11,7 +11,10 @@ use std::{
 };
 
 /// run_record runs through a Reel sequence using the darkroom::Record struct
-pub fn run_record(cmd: Record, base_params: BaseParams) -> Result<(), Error> {
+pub fn run_record(cmd: Record, mut base_params: BaseParams) -> Result<(), Error> {
+    base_params = base_params
+        .with_timeout(cmd.timeout)
+        .with_timestamp(cmd.timestamp);
     let cut_str = fr::file_to_string(cmd.get_cut_file())?;
     let mut cut_register: Register = Register::from(&cut_str)?;
     let frame_range = match cmd.range {
@@ -43,7 +46,8 @@ pub fn run_record(cmd: Record, base_params: BaseParams) -> Result<(), Error> {
             .as_ref()
             .map(|dir| take_output(&dir, &&meta_frame.path));
         warn!(
-            "{} {:?}",
+            "{}{} {:?}",
+            base_params.get_timestamp(),
             "File:".yellow(),
             meta_frame
                 .get_filename()
@@ -61,6 +65,13 @@ pub fn run_record(cmd: Record, base_params: BaseParams) -> Result<(), Error> {
             return Err(e);
         }
     }
+    base_params.warn_timestamp();
+    warn!(
+        "{}{}{}",
+        "= ".green(),
+        "Success 🎉 ".yellow(),
+        "==========\n".green()
+    );
 
     write_cut(&base_params.cut_out, &cut_register, &cmd.reel_name, false)?;
 

--- a/src/take.rs
+++ b/src/take.rs
@@ -193,8 +193,8 @@ pub fn run_take(
                 "attempt [{}/{}] | interval [{}{}]",
                 n.to_string().yellow(),
                 attempts.times,
-                attempts.ms,
-                "ms".yellow(),
+                attempts.ms.to_string().yellow(),
+                "ms",
             );
             if let Ok(response) = run_request(&params, frame) {
                 if process_response(params.clone(), frame, register, response, output.clone())

--- a/src/take.rs
+++ b/src/take.rs
@@ -227,11 +227,7 @@ pub fn single_take(cmd: Take, base_params: BaseParams) -> Result<(), Error> {
     let get_metaframe = || MetaFrame::try_from(cmd.frame.clone());
 
     // Frame to be mutably borrowed
-    let frame = Frame::new(&frame_str).context(
-        get_metaframe()?
-            .get_filename()
-            .expect("MetaFrame.get_filename() panic"),
-    )?;
+    let frame = Frame::new(&frame_str).context(get_metaframe()?.get_filename())?;
     let mut payload_frame = frame.clone();
     let mut cut_register = Register::from(&cut_str)?;
     if let Err(e) = run_take(

--- a/test_data/post.03s.delay.fr.json
+++ b/test_data/post.03s.delay.fr.json
@@ -1,0 +1,20 @@
+{
+  "cut": {
+    "from": [
+      "ADDRESS"
+    ],
+    "to": {
+      "body": "'response'.'body'"
+    }
+  },
+  "protocol": "HTTP",
+  "request": {
+    "body": "the exact body that is sent",
+    "uri": "POST /delay/3",
+    "entrypoint": "${ADDRESS}"
+  },
+  "response": {
+    "body": "${body}",
+    "status": 200
+  }
+}


### PR DESCRIPTION
* timestamps are added to recordings: `dark record record ./test_data post --timestamp`
* 30 sec default timeout can now be overridden: `dark record record ./test_data post --timeout 2`