### PR TITLE
Implement reference selector

### DIFF
--- a/filmreel/Cargo.toml
+++ b/filmreel/Cargo.toml
@@ -21,6 +21,8 @@ glob  = "0.3"
 jql = "2.8"
 lazy_static = "1.4.0"
 paste = "1.0.5"
+pest = "2.1"
+pest_derive = "2.1"
 pretty_assertions = "0.7.1"
 regex = "1.4"
 serde = { version = "1.0.118", features = ["derive"] }

--- a/filmreel/src/error.rs
+++ b/filmreel/src/error.rs
@@ -1,4 +1,6 @@
+use crate::utils::Rule;
 use colored::*;
+use pest::error::Error as PestError;
 use serde_json::error::{Category, Error as SerdeError};
 use std::{error::Error, fmt};
 
@@ -13,6 +15,8 @@ pub enum FrError {
     ReadInstructionf(&'static str, String),
     ReelParse(&'static str),
     Serde(String),
+    Parse(String),
+    Pest(PestError<Rule>),
 }
 
 impl Error for FrError {
@@ -39,6 +43,12 @@ impl From<SerdeError> for FrError {
     }
 }
 
+impl From<PestError<Rule>> for FrError {
+    fn from(err: PestError<Rule>) -> FrError {
+        Self::Pest(err)
+    }
+}
+
 impl fmt::Display for FrError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -60,6 +70,14 @@ impl fmt::Display for FrError {
             }
             FrError::Serde(msg) => {
                 writeln!(f, "SerdeError {} {}", "-->".red(), msg)?;
+                Ok(())
+            }
+            FrError::Parse(msg) => {
+                writeln!(f, "ParseError {} {}", "-->".red(), msg)?;
+                Ok(())
+            }
+            FrError::Pest(msg) => {
+                writeln!(f, "PestError {} {}", "-->".red(), msg)?;
                 Ok(())
             }
         }

--- a/filmreel/src/error.rs
+++ b/filmreel/src/error.rs
@@ -6,6 +6,7 @@ use std::{error::Error, fmt};
 
 /// An error that occurred during parsing or hydrating a filmReel file
 #[derive(Debug, PartialEq)]
+#[non_exhaustive]
 pub enum FrError {
     FrameParse(&'static str),
     FrameParsef(&'static str, String),

--- a/filmreel/src/selector.pest
+++ b/filmreel/src/selector.pest
@@ -1,0 +1,15 @@
+
+selector = { "."? ~ (step ~ ".")* ~ (step ~ "."?)?  }
+
+step = _{ string | index }
+
+delim = _{ "'" }
+string = { delim ~ inner ~ delim }
+inner = { char* }
+char = {
+    !("\\" | "'") ~ ANY 
+    | "\\" ~ "'"
+}
+
+index = _{ "[" ~ int ~ "]" }
+int = { ASCII_DIGIT+ }

--- a/filmreel/src/selector.pest
+++ b/filmreel/src/selector.pest
@@ -1,15 +1,23 @@
+// Example: 'test'.[0] decomposes into the selector wrapper and one string + one int token
+// - selector
+//  - string: "test"
+//  - int: "0"
 
+// selector is a period delimited series of zero or more steps 
 selector = { "."? ~ (step ~ ".")* ~ (step ~ "."?)?  }
 
-step = _{ string | index }
+// step represents either an array index selection or an object key
+step = _{ outer | index }
 
-delim = _{ "'" }
-string = { delim ~ inner ~ delim }
-inner = { char* }
-char = {
-    !("\\" | "'") ~ ANY 
-    | "\\" ~ "'"
+// outer handles the quote delimited string
+outer = _{ "'" ~ string ~ "'" }
+string = { char* }
+
+char = _{
+    !("\\" | "'") ~ ANY // Any character that is not a backslash or single quote
+    | "\\" ~ "'"        // ... or an escaped backslash
 }
 
+// represents a square bracket delimited array index
 index = _{ "[" ~ int ~ "]" }
 int = { ASCII_DIGIT+ }

--- a/filmreel/src/utils.rs
+++ b/filmreel/src/utils.rs
@@ -1,6 +1,8 @@
 use crate::error::FrError;
+use pest::{error::Error, iterators::Pair, Parser};
+use pest_derive::*;
 use serde::{Serialize, Serializer};
-use serde_json::Value;
+use serde_json::{value::Index, Value};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 /// Serializes a HashMap into a BTreeMap, sorting key order for serialization.
@@ -38,5 +40,145 @@ pub fn get_jql_value(val: &Value, query: &str) -> Result<Value, FrError> {
             v => Ok(v),
         },
         Err(e) => Err(FrError::ReadInstructionf("get_jql_value", e)),
+    }
+}
+
+#[derive(Parser)]
+#[grammar = "selector.pest"]
+pub struct SelectorParser;
+
+type Selector = Box<dyn Fn(&'_ mut Value) -> Option<&'_ mut Value>>;
+
+pub fn new_selector(selector_str: &str) -> Result<Selector, FrError> {
+    let pairs = SelectorParser::parse(Rule::selector, selector_str)?
+        .next()
+        .unwrap();
+
+    // check for token string length to invalidate instances where selector_str is "" or "''", "''.''",
+    // etc...
+    if pairs.as_str().len() == 0 {
+        return Err(FrError::ReadInstruction(
+            "validation selector cannot have an empty query".into(),
+        ));
+    }
+
+    let mut generator: Vec<Selector> = vec![];
+    for pair in pairs.into_inner() {
+        match pair.as_rule() {
+            Rule::string => {
+                let key = pair
+                    .into_inner()
+                    .next()
+                    .unwrap()
+                    .as_str()
+                    .replace("\\'", "'");
+                let key_selector: Selector = Box::new(move |x: &mut Value| x.get_mut(key.clone()));
+                generator.push(key_selector);
+            }
+            Rule::int => {
+                let index = pair
+                    .as_str()
+                    .parse::<usize>()
+                    .map_err(|x| FrError::Parse(x.to_string()))?;
+                let index_selector: Selector = Box::new(move |x: &mut Value| x.get_mut(index));
+                generator.push(index_selector);
+            }
+            Rule::selector | Rule::step | Rule::delim | Rule::inner | Rule::char | Rule::index => {
+                unreachable!()
+            }
+        }
+    }
+
+    let selector_fn: Selector = Box::new(move |x: &mut Value| -> Option<&mut Value> {
+        let mut drilled_value = x;
+        for sel in generator.iter() {
+            drilled_value = sel(drilled_value)?;
+        }
+        Some(drilled_value)
+    });
+
+    Ok(selector_fn)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::*;
+
+    const OBJ_JSON: &str = r#"{"key":{"obj":true,"array":[false,true]}}"#;
+    const ARR_JSON: &str = r#"[{"key":"value"},1,[],[true]]"#;
+
+    type IndexList = Vec<Box<dyn Index>>;
+    fn selector_case(case: u32) -> (&'static str, &'static str, IndexList) {
+        match case {
+            1 => (
+                OBJ_JSON,
+                "'key'.'array'.[1]",
+                vec![Box::new("key"), Box::new("array"), Box::new(1)],
+            ),
+            2 => (
+                OBJ_JSON,
+                ".", // returns entire OBJ_JSON
+                vec![],
+            ),
+            3 => (
+                OBJ_JSON,
+                "'key'.'array'.[3]", // should panic: out of bounds array index of 3
+                vec![Box::new("key"), Box::new("array"), Box::new(1)],
+            ),
+            4 => (
+                OBJ_JSON,
+                "", // should panic: None is returned
+                vec![],
+            ),
+            5 => (ARR_JSON, "[3].[0]", vec![Box::new(3), Box::new(0)]),
+            6 => (ARR_JSON, "[0].'key'", vec![Box::new(0), Box::new("key")]),
+            // should panic: acessing index 1 of empty array
+            7 => (ARR_JSON, "[2].[1]", vec![Box::new(2), Box::new(1)]),
+            _ => unreachable!(),
+        }
+    }
+
+    #[rstest(selector_case,
+        case(selector_case(1)),
+        case(selector_case(2)),
+        #[should_panic]
+        case(selector_case(3)),
+        #[should_panic]
+        case(selector_case(4)),
+        case(selector_case(5)),
+        case(selector_case(6)),
+        #[should_panic]
+        case(selector_case(7))
+            )]
+    fn test_obj_selection(selector_case: (&str, &str, IndexList)) {
+        let (json_str, selector_str, index_list) = selector_case;
+        // 1. create two representations of the deserialized JSON
+        let mut actual_value: Value = serde_json::from_str(json_str).expect("from_str error");
+        let expected_value: Value = serde_json::from_str(json_str).expect("from_str error");
+        // 2, create our selector closure;
+        let selector = new_selector(selector_str).unwrap();
+
+        // 3. loop through a list of array and object indices to simulate successive
+        // indices so that       | value[a][b][c]
+        // can be represented as | value.get(a).unwrap().get(b).unwrap().get(c).unwrap()
+        let index_iter = move |value: &Value| -> Value {
+            let mut output = value;
+            for v in index_list.iter() {
+                output = v.index_into(output).unwrap();
+            }
+            output.clone()
+        };
+        let expected_selection = index_iter(&expected_value);
+
+        let selected_value = selector(&mut actual_value).unwrap();
+        // 4. assert that the selector_str matches the expected result using successive
+        // Index.index_into(Value) calls
+        assert_eq!(&expected_selection, selected_value);
+
+        // 5. assert that our selection can be valid in changing the original reference
+        let arr_val = selector(&mut actual_value).unwrap();
+        *arr_val = "new_value".into();
+        assert_eq!(index_iter(&actual_value), "new_value".to_string());
     }
 }

--- a/filmreel/src/utils.rs
+++ b/filmreel/src/utils.rs
@@ -120,6 +120,7 @@ mod tests {
                 OBJ_JSON,
                 ".", // returns entire OBJ_JSON
                 vec![],
+                // r#"{"key":{"obj":true,"array":[false,true]}}"#,
             ),
             3 => (
                 OBJ_JSON,
@@ -171,14 +172,14 @@ mod tests {
         };
         let expected_selection = index_iter(&expected_value);
 
-        let selected_value = selector(&mut actual_value).unwrap();
+        let mut selected_value = selector(&mut actual_value).unwrap();
         // 4. assert that the selector_str matches the expected result using successive
         // Index.index_into(Value) calls
         assert_eq!(&expected_selection, selected_value);
 
-        // 5. assert that our selection can be valid in changing the original reference
-        let arr_val = selector(&mut actual_value).unwrap();
-        *arr_val = "new_value".into();
+        // 5. assert that our selection can be validly mutated and reflected in the original value
+        selected_value = selector(&mut actual_value).unwrap();
+        *selected_value = "new_value".into();
         assert_eq!(index_iter(&actual_value), "new_value".to_string());
     }
 }


### PR DESCRIPTION
Added `new_selector` function that takes [jql](https://github.com/yamafaktory/jql) syntax giving a closure that returns a  mutable reference for a given `Value` using a selection string.