### PR TITLE
jql feature toggle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ argh = { git = "https://github.com/google/argh" }
 colored = "2.0.0"
 colored-diff = "0.2.2"
 colored_json = "2.1.0"
-filmreel = { version = "0.5", path = "filmreel" }
+filmreel = { version = "0.5.1", path = "filmreel" }
 http = "0.2.4"
 lazy_static = "1.4.0"
 log = { version = "0.4.14", features = ["std"] }

--- a/filmreel/Cargo.toml
+++ b/filmreel/Cargo.toml
@@ -26,6 +26,7 @@ pretty_assertions = "0.7.2"
 regex = "1.5.3"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
+serde-hashkey = "0.4.0"
 
 jql = { version = "2.9.4", optional = true }
 

--- a/filmreel/Cargo.toml
+++ b/filmreel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filmreel"
-version = "0.5.0"
+version = "0.5.1"
 description = "filmReel parser for Rust"
 authors = ["Mikhail Katychev <mkatych@gmail.com>"]
 edition = "2018"
@@ -16,23 +16,23 @@ name = "filmreel"
 path = "src/lib.rs"
 
 [dependencies]
-colored = "2.0"
-glob  = "0.3"
+colored = "2.0.0"
+glob  = "0.3.0"
 lazy_static = "1.4.0"
 paste = "1.0.5"
-pest = "2.1"
-pest_derive = "2.1"
-pretty_assertions = "0.7.1"
-regex = "1.4"
-serde = { version = "1.0.118", features = ["derive"] }
-serde_json = "1.0"
+pest = "2.1.3"
+pest_derive = "2.1.0"
+pretty_assertions = "0.7.2"
+regex = "1.5.3"
+serde = { version = "1.0.125", features = ["derive"] }
+serde_json = "1.0.64"
 
-jql = { version = "2.8", optional = true }
+jql = { version = "2.9.4", optional = true }
 
 [features]
 default = []
 full_jql = ["jql"]
 
 [dev-dependencies]
-rstest = "0.6"
+rstest = "0.9.0"
 paste = "1.0.5"

--- a/filmreel/Cargo.toml
+++ b/filmreel/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/lib.rs"
 [dependencies]
 colored = "2.0"
 glob  = "0.3"
-jql = "2.8"
 lazy_static = "1.4.0"
 paste = "1.0.5"
 pest = "2.1"
@@ -27,6 +26,12 @@ pretty_assertions = "0.7.1"
 regex = "1.4"
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0"
+
+jql = { version = "2.8", optional = true }
+
+[features]
+default = []
+full_jql = ["jql"]
 
 [dev-dependencies]
 rstest = "0.6"

--- a/filmreel/src/response.rs
+++ b/filmreel/src/response.rs
@@ -273,7 +273,7 @@ impl Validator {
 
     fn apply_unordered(
         &self,
-        selector: Selector,
+        selector: MutSelector,
         self_body: &mut Value,
         other_body: &mut Value,
     ) -> Result<(), FrError> {

--- a/filmreel/src/response.rs
+++ b/filmreel/src/response.rs
@@ -2,7 +2,7 @@ use crate::{
     cut::Register,
     error::FrError,
     frame::*,
-    utils::{get_jql_value, new_selector, Selector},
+    utils::{get_jql_value, new_mut_selector, MutSelector},
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, to_value, Value};
@@ -102,7 +102,7 @@ impl<'a> Response<'a> {
                 continue;
             }
 
-            let selector = new_selector(strip_query(k))?;
+            let selector = new_mut_selector(strip_query(k))?;
             match (v.partial, v.unordered) {
                 (false, false) => {
                     unreachable!();
@@ -186,7 +186,7 @@ impl Validator {
     // partial validation?
     fn apply_partial(
         &self,
-        selector: Selector,
+        selector: MutSelector,
         self_body: &mut Value,
         other_body: &mut Value,
     ) -> Result<(), FrError> {

--- a/filmreel/src/response.rs
+++ b/filmreel/src/response.rs
@@ -2,7 +2,7 @@ use crate::{
     cut::Register,
     error::FrError,
     frame::*,
-    utils::{get_jql_value, new_mut_selector, MutSelector},
+    utils::{new_mut_selector, select_value, MutSelector},
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, to_value, Value};
@@ -62,7 +62,7 @@ impl<'a> Response<'a> {
         let mut write_matches: HashMap<&str, Value> = HashMap::new();
         for (k, query) in set.writes.iter() {
             // ensure frame jql query returns a string object
-            let frame_str = match get_jql_value(&frame_response, query) {
+            let frame_str = match select_value(&frame_response, query) {
                 Ok(Value::String(v)) => Ok(v),
                 Ok(_) => Err(FrError::FrameParsef(
                     INVALID_INSTRUCTION_TYPE_ERR,
@@ -70,7 +70,7 @@ impl<'a> Response<'a> {
                 )),
                 Err(e) => Err(e),
             }?;
-            let payload_val = get_jql_value(&payload_response, query)?;
+            let payload_val = select_value(&payload_response, query)?;
 
             if let Value::String(payload_str) = &payload_val {
                 let write_match = Register::write_match(k, &frame_str, payload_str)?;

--- a/filmreel/src/utils.rs
+++ b/filmreel/src/utils.rs
@@ -33,7 +33,7 @@ where
 }
 
 #[cfg(feature = "full_jql")]
-pub fn get_jql_value(val: &Value, query: &str) -> Result<Value, FrError> {
+pub fn select_value(val: &Value, query: &str) -> Result<Value, FrError> {
     let selectors = query.replace("'", "\"");
     match jql::walker(val, Some(&selectors)) {
         Ok(v) => match v {

--- a/filmreel/src/utils.rs
+++ b/filmreel/src/utils.rs
@@ -45,7 +45,7 @@ pub fn get_jql_value(val: &Value, query: &str) -> Result<Value, FrError> {
 }
 
 #[cfg(not(feature = "full_jql"))]
-pub fn get_jql_value(val: &Value, query: &str) -> Result<Value, FrError> {
+pub fn select_value(val: &Value, query: &str) -> Result<Value, FrError> {
     let selector = new_selector(query)?;
     match selector(val) {
         Some(v) => match v {

--- a/filmreel/src/utils.rs
+++ b/filmreel/src/utils.rs
@@ -32,6 +32,7 @@ where
     ordered.serialize(serializer)
 }
 
+#[cfg(feature = "full_jql")]
 pub fn get_jql_value(val: &Value, query: &str) -> Result<Value, FrError> {
     let selectors = query.replace("'", "\"");
     match jql::walker(val, Some(&selectors)) {
@@ -43,11 +44,81 @@ pub fn get_jql_value(val: &Value, query: &str) -> Result<Value, FrError> {
     }
 }
 
+#[cfg(not(feature = "full_jql"))]
+pub fn get_jql_value(val: &Value, query: &str) -> Result<Value, FrError> {
+    let selector = new_selector(query)?;
+    match selector(val) {
+        Some(v) => match v {
+            Value::String(_) => Ok(v.clone()),
+            v => Ok(v.clone()),
+        },
+        None => Err(FrError::ReadInstructionf(
+            "get_jql_value did not return a selection: {}",
+            query.to_string(),
+        )),
+    }
+}
+
 #[derive(Parser)]
 #[grammar = "selector.pest"]
 pub struct SelectorParser;
 
-pub type Selector = Box<dyn Fn(&'_ mut Value) -> Option<&'_ mut Value>>;
+pub type Selector = Box<dyn Fn(&'_ Value) -> Option<&'_ Value>>;
+pub type MutSelector = Box<dyn Fn(&'_ mut Value) -> Option<&'_ mut Value>>;
+
+pub fn new_mut_selector(query: &str) -> Result<MutSelector, FrError> {
+    let pairs = SelectorParser::parse(Rule::selector, query)?
+        .next()
+        .unwrap();
+
+    // check for token string length to invalidate instances where selector_str is "" or "''", "''.''",
+    // etc...
+    if pairs.as_str().is_empty() {
+        return Err(FrError::ReadInstruction(
+            "validation selector cannot have an empty query",
+        ));
+    }
+
+    let mut generator: Vec<MutSelector> = vec![];
+    for pair in pairs.into_inner() {
+        match pair.as_rule() {
+            Rule::string => {
+                let key = pair.as_str().replace("\\'", "'");
+                let key_selector: MutSelector =
+                    Box::new(move |x: &mut Value| x.get_mut(key.to_owned()));
+                generator.push(key_selector);
+            }
+            Rule::int => {
+                let index = pair
+                    .as_str()
+                    .parse::<usize>()
+                    .map_err(|x| FrError::Parse(x.to_string()))?;
+                let index_selector: MutSelector = Box::new(move |x: &mut Value| x.get_mut(index));
+                generator.push(index_selector);
+            }
+            // selector will always be the only pair at the top level of the genreated AST
+            // all other rules are "silent" and never tokenized, this is represented by the leading
+            // underscore in pest:
+            //
+            // step = _{ outer | index }
+            //
+            // Therefore all other rules should be unreachable
+            Rule::selector | Rule::step | Rule::outer | Rule::char | Rule::index => {
+                unreachable!()
+            }
+        }
+    }
+
+    let selector_fn: MutSelector = Box::new(move |x: &mut Value| -> Option<&mut Value> {
+        let mut drilled_value = x;
+        for sel in generator.iter() {
+            drilled_value = sel(drilled_value)?;
+        }
+        Some(drilled_value)
+    });
+
+    Ok(selector_fn)
+}
 
 pub fn new_selector(query: &str) -> Result<Selector, FrError> {
     let pairs = SelectorParser::parse(Rule::selector, query)?
@@ -67,8 +138,7 @@ pub fn new_selector(query: &str) -> Result<Selector, FrError> {
         match pair.as_rule() {
             Rule::string => {
                 let key = pair.as_str().replace("\\'", "'");
-                let key_selector: Selector =
-                    Box::new(move |x: &mut Value| x.get_mut(key.to_owned()));
+                let key_selector: Selector = Box::new(move |x: &Value| x.get(key.to_owned()));
                 generator.push(key_selector);
             }
             Rule::int => {
@@ -76,7 +146,7 @@ pub fn new_selector(query: &str) -> Result<Selector, FrError> {
                     .as_str()
                     .parse::<usize>()
                     .map_err(|x| FrError::Parse(x.to_string()))?;
-                let index_selector: Selector = Box::new(move |x: &mut Value| x.get_mut(index));
+                let index_selector: Selector = Box::new(move |x: &Value| x.get(index));
                 generator.push(index_selector);
             }
             // selector will always be the only pair at the top level of the genreated AST
@@ -92,7 +162,7 @@ pub fn new_selector(query: &str) -> Result<Selector, FrError> {
         }
     }
 
-    let selector_fn: Selector = Box::new(move |x: &mut Value| -> Option<&mut Value> {
+    let selector_fn: Selector = Box::new(move |x: &Value| -> Option<&Value> {
         let mut drilled_value = x;
         for sel in generator.iter() {
             drilled_value = sel(drilled_value)?;
@@ -173,7 +243,7 @@ mod tests {
         let mut actual_value: Value = serde_json::from_str(json_str).expect("from_str error");
         let expected_value: Value = serde_json::from_str(json_str).expect("from_str error");
         // 2, create our selector closure;
-        let selector = new_selector(query).unwrap();
+        let selector = new_mut_selector(query).unwrap();
 
         // 3. loop through a list of array and object indices to simulate successive
         // indices so that       | value[a][b][c]


### PR DESCRIPTION
the `jql` library is now an toggleable feature flag, off by default:

```
cargo build --features=filmreel/full_jql --target-dir=./jql --release
```

with  `filmreel/full_jql` turned off, binary size is reduced, performance increased, but at the cost of limited query capability:

```sh
$ cargo build --no-default-features --features=filmreel/full_jql --target-dir=./jql --release
$ exa -la --no-time --no-user --no-permissions ./jql/release/dark
6.9M ./jql/release/dark


$ cargo build --no-default-features --target-dir=./no_jql --release
$ exa -la --no-time --no-user --no-permissions ./no_jql/release/dark
6.5M ./no_jql/release/dark
```