### PR TITLE
mdcat build error for a positional argument that was not provided

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde_json = "1.0.64"
 url = "2.2.1"
 which = "4.1.0"
 
-mdcat = { version = "0.22.4", optional = true }
+mdcat = { version = "0.24.0", optional = true }
 syntect = { version = "4.5.0", optional = true }
 pulldown-cmark = { version = "0.8.0", optional = true }
 minus = { version = "3.4.0", optional = true, features = ["static_output"] }


### PR DESCRIPTION
Was trying to build darkroom and was getting the below error until 0.24.* version of mdcat built.  The most recent version of mdcat won't build either because it breaks one of the api's we're using slightly?  I'm not sure, it's Rust stuff and I don't know rust very well. 

This built darkroom though
```
   Compiling reqwest v0.11.10
error: 1 positional argument in format string, but no arguments were given
   --> /Users/christiangriggs/.cargo/registry/src/github.com-1ecc6299db9ec823/mdcat-0.23.2/src/resources.rs:160:48
    |
160 |         _ => Err(anyhow!("Cannot read from URL {}, protocol not supported")),
    |                                                ^^

The following warnings were emitted during compilation:

warning: Failed to build manpage: No such file or directory (os error 2)

error: could not compile `mdcat` due to previous error
warning: build failed, waiting for other jobs to finish...
error: failed to compile `darkroom v0.7.4 (/Users/christiangriggs/Documents/darkroom)`, intermediate artifacts can be found at `/Users/christiangriggs/Documents/darkroom/target`
```