### PR TITLE
Remove nullification of validation for retries

### DIFF
--- a/filmreel/src/response.rs
+++ b/filmreel/src/response.rs
@@ -128,9 +128,6 @@ impl<'a> Response<'a> {
             }
         }
 
-        // for comparison's sake set validtion to None once applying is finished
-        self.validation = None;
-
         Ok(())
     }
 }


### PR DESCRIPTION
The validation rules were getting zeroed out after running, which causes the validation rules to not be present on subsequent retries.

This PR solves this by removing the nullification of the validation, since that appears to be not needed anyway.